### PR TITLE
NSC-8143 Serverless用のNode.js Dockerイメージを作成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+/.github
+/.idea
+.gitignore
+LICENSE
+serverless-node-docker.iml
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8.10-alpine
+
+RUN set -x && \
+  npm install -g npm && \
+  npm install -g yarn && \
+  yarn global add serverless@1.37.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 Serverless環境（主にAWS Lambda）で利用するDockerfileを管理する
 
+`node:8.10-alpine`をベースとしたイメージです。`serverless`がインストールされています。
+
+
 ## Docker Hub
 
 https://cloud.docker.com/u/nursesenka/repository/registry-1.docker.io/nursesenka/serverless-node
@@ -14,7 +17,22 @@ https://dockeri.co/
 
 ## 検証手順
 
-※ 後で記載します。
+ビルドが実行できることを確認してください。
+
+```
+docker build -t nursesenka/serverless-node .
+```
+
+`docker images`を実行し、`nursesenka/serverless-node  `というイメージが作成されていることを確認してください。
+```
+REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+nursesenka/serverless-node         latest              ef098b358ad0        8 minutes ago       177MB
+```
+
+下記を実行し、コンテナが起動できることとserverlessのバージョンが表示されることを確認してください。
+```
+docker run -it nursesenka/serverless-node serverless -v
+```
 
 ## 自動Buildについて
 


### PR DESCRIPTION
# 課題URL（JIRAかGitHub issue）
https://smsc-co-ltd.atlassian.net/browse/NSC-8143

# PRのDoneの定義
https://smsc-co-ltd.atlassian.net/browse/NSC-8143 の完了条件が満たされていること

# 変更点概要
Imageを作成するDockerfileを追加。serverlessは、現時点での最新バージョン`1.37.0`としている。
`.dockerignore`を追加。
READMEに、ローカルのDockerfileの検証手順を追加。