### PR TITLE
NSC-8465 コンテナの実行ユーザーをrootを使わないように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,21 @@ FROM node:8.10-alpine
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
+ENV YARN_VERSION 1.13.0
 
 RUN set -x && \
-  npm install -g npm && \
-  npm install -g yarn && \
-  yarn global add serverless@1.38.0 && \
-  apk add --update --no-cache tzdata && \
+  apk add --update --no-cache tzdata --virtual .build-deps-yarn curl && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
-  apk del tzdata
+  apk del tzdata && \
+  curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" && \
+  tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ && \
+  ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn && \
+  ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg && \
+  rm yarn-v$YARN_VERSION.tar.gz && \
+  apk del .build-deps-yarn && \
+  npm install --global npm@6.9.0 && \
+  yarn global add serverless@1.38.0
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM node:8.10-alpine
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
 RUN set -x && \
   npm install -g npm && \
   npm install -g yarn && \
-  yarn global add serverless@1.37.0 && \
+  yarn global add serverless@1.38.0 && \
   apk add --update --no-cache tzdata && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata
+
+USER node
+
+WORKDIR /home/node


### PR DESCRIPTION
# 課題URL（JIRAかGitHub issue）
https://smsc-co-ltd.atlassian.net/browse/NSC-8465

# PRのDoneの定義
- https://smsc-co-ltd.atlassian.net/browse/NSC-8465の完了条件を満たしている事

# 変更点概要
- コンテナを実行するユーザーを一般ユーザーの `node` に変更

# 補足情報
https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md に載っている情報を参照。
